### PR TITLE
Implement User Permissions design

### DIFF
--- a/components/user_access/app/models/user_access/permission.rb
+++ b/components/user_access/app/models/user_access/permission.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: user_access_permissions
+#
+#  id          :bigint           not null, primary key
+#  code        :string           not null
+#  description :string
+#  name        :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+# Indexes
+#
+#  index_user_access_permissions_on_code  (code)
+#
+module UserAccess
+  class Permission < ApplicationRecord
+  end
+end

--- a/components/user_access/app/models/user_access/role_to_permission.rb
+++ b/components/user_access/app/models/user_access/role_to_permission.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: user_access_role_to_permissions
+#
+#  id              :bigint           not null, primary key
+#  permission_code :string           not null
+#  role_code       :integer          not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#
+# Indexes
+#
+#  index_user_access_role_to_permissions_on_permission_code  (permission_code)
+#  index_user_access_role_to_permissions_on_role_code        (role_code)
+#
+module UserAccess
+  class RoleToPermission < ApplicationRecord
+    belongs_to :permission, primary_key: :code, foreign_key: :permission_code
+  end
+end

--- a/components/user_access/app/models/user_access/user.rb
+++ b/components/user_access/app/models/user_access/user.rb
@@ -30,6 +30,10 @@ module UserAccess
 
     attr_accessor :skip_password_validation  # virtual attribute to skip password validation while saving
 
+    has_many :user_roles
+    has_many :role_to_permissions, through: :user_roles
+    has_many :permissions, through: :role_to_permissions
+
     validates_uniqueness_of :email, :login
     validates_presence_of :email, :encrypted_password, :first_name, :last_name, :name,
                           :login, :is_active

--- a/components/user_access/app/models/user_access/user_role.rb
+++ b/components/user_access/app/models/user_access/user_role.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: user_access_user_roles
+#
+#  id         :bigint           not null, primary key
+#  role_code  :integer          not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_user_access_user_roles_on_role_code  (role_code)
+#  index_user_access_user_roles_on_user_id    (user_id)
+#
+module UserAccess
+  class UserRole < ApplicationRecord
+    belongs_to :user
+    belongs_to :role_to_permission, primary_key: :role_code, foreign_key: :role_code
+
+    enum role_code: {
+      member: 0,
+      administrator: 1
+    }
+  end
+end

--- a/db/migrate/20220125004254_create_user_access_user_roles.rb
+++ b/db/migrate/20220125004254_create_user_access_user_roles.rb
@@ -1,0 +1,10 @@
+class CreateUserAccessUserRoles < ActiveRecord::Migration[6.1]
+  def change
+    create_table :user_access_user_roles do |t|
+      t.bigint :user_id, null: false, index: true
+      t.integer :role_code, null: false, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220125004423_create_user_access_role_to_permissions.rb
+++ b/db/migrate/20220125004423_create_user_access_role_to_permissions.rb
@@ -1,0 +1,10 @@
+class CreateUserAccessRoleToPermissions < ActiveRecord::Migration[6.1]
+  def change
+    create_table :user_access_role_to_permissions do |t|
+      t.integer :role_code, null: false, index: true
+      t.string :permission_code, null: false, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220125004537_create_user_access_permissions.rb
+++ b/db/migrate/20220125004537_create_user_access_permissions.rb
@@ -1,0 +1,11 @@
+class CreateUserAccessPermissions < ActiveRecord::Migration[6.1]
+  def change
+    create_table :user_access_permissions do |t|
+      t.string :code, null: false, index: true
+      t.string :name, null: false
+      t.string :description
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,6 +14,24 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_10_200906) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
+  create_table "user_access_permissions", force: :cascade do |t|
+    t.string "code", null: false
+    t.string "name", null: false
+    t.string "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["code"], name: "index_user_access_permissions_on_code"
+  end
+
+  create_table "user_access_role_to_permissions", force: :cascade do |t|
+    t.integer "role_code", null: false
+    t.string "permission_code", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["permission_code"], name: "index_user_access_role_to_permissions_on_permission_code"
+    t.index ["role_code"], name: "index_user_access_role_to_permissions_on_role_code"
+  end
+
   create_table "user_access_user_registrations", force: :cascade do |t|
     t.string "login", null: false
     t.string "email", null: false
@@ -29,6 +47,15 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_10_200906) do
     t.string "confirmation_token"
     t.datetime "confirmation_sent_at", precision: nil
     t.string "unconfirmed_email"
+  end
+
+  create_table "user_access_user_roles", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.integer "role_code", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["role_code"], name: "index_user_access_user_roles_on_role_code"
+    t.index ["user_id"], name: "index_user_access_user_roles_on_user_id"
   end
 
   create_table "user_access_users", force: :cascade do |t|


### PR DESCRIPTION
In the original repo they have the same DB structure, but for `UserRole`, `RoleToPermission`, and `Permission` instead of having the models they have a DB view which they use directly. As long as we follow their design I'm good with a more Railsy implementation, WDYT?

In the end, the only thing that matters is the ability to do `user.permissions`, right? In the original repo they use the DB view `UserPermissions` here `src/Modules/UserAccess/Application/Authorization/**/*`